### PR TITLE
add the possibility to blacklist hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,3 +147,15 @@ const vcr = new VCR(new DatabaseStorage());
 
 For more details refer to the [FileStorage](https://github.com/epignosisx/vcr-test/blob/main/src/file-storage.ts) implementation.
 
+### Blacklist Hosts
+You may want to ignore some hosts from being recorded. You can do this by setting the `blacklistHosts` property:
+
+```ts
+const vcr = new VCR(...);
+vcr.blacklistHosts = ['example.com'];
+await vcr.useCassette('blacklistedHost', async () => {
+  // This will not be recorded
+  await axios.get('https://httpbin.dev/get');
+  await axios.get('https://httpbin.org/get');
+}, ['httpbin.dev']);
+```

--- a/README.md
+++ b/README.md
@@ -151,8 +151,6 @@ For more details refer to the [FileStorage](https://github.com/epignosisx/vcr-te
 You may want to ignore some hosts from being recorded. You can do this by setting the `blacklistHosts` property:
 
 ```ts
-const vcr = new VCR(...);
-vcr.blacklistHosts = ['example.com'];
 await vcr.useCassette('blacklistedHost', async () => {
   // This will not be recorded
   await axios.get('https://httpbin.dev/get');

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "main": "dist/index.js",
   "scripts": {
     "test": "jest --config './jest.config.js' --verbose",
-    "build": "tsc"
+    "build": "tsc",
+    "prepare": "tsc"
   },
   "author": "epignosisx",
   "repository": {

--- a/src/cassette.ts
+++ b/src/cassette.ts
@@ -21,6 +21,7 @@ export class Cassette {
     private readonly name: string,
     private readonly mode: RecordMode,
     private readonly masker: HttpRequestMasker,
+    private readonly hostBlacklist: string[] = [],
   ) {}
 
   public isDone(): boolean {
@@ -37,6 +38,9 @@ export class Cassette {
     this.interceptor.apply();
 
     this.interceptor.on('request', async ({ request, requestId }) => {
+      if (this.hostBlacklist.includes(new URL(request.url).host)) {
+          return;
+      }
       if (this.mode === RecordMode.none) {
         return this.playback(request);
       }
@@ -49,6 +53,9 @@ export class Cassette {
     });
 
     this.interceptor.on('response', async ({ response, request }) => {
+      if (this.hostBlacklist.includes(new URL(request.url).host)) {
+        return;
+      }
       const req: Request = request.clone();
       const res: Response = response.clone();
 

--- a/src/cassette.ts
+++ b/src/cassette.ts
@@ -38,7 +38,7 @@ export class Cassette {
     this.interceptor.apply();
 
     this.interceptor.on('request', async ({ request, requestId }) => {
-      if (this.hostBlacklist.includes(new URL(request.url).host)) {
+      if (this.hostBlacklist.includes(new URL(request.url).hostname)) {
           return;
       }
       if (this.mode === RecordMode.none) {
@@ -53,7 +53,7 @@ export class Cassette {
     });
 
     this.interceptor.on('response', async ({ response, request }) => {
-      if (this.hostBlacklist.includes(new URL(request.url).host)) {
+      if (this.hostBlacklist.includes(new URL(request.url).hostname)) {
         return;
       }
       const req: Request = request.clone();

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -64,7 +64,7 @@ describe('cassette', () => {
     });
   });
 
-  it('does not recored blacklisted host', async () => {
+  it('does not record blacklisted host', async () => {
     var vcr = new VCR(new FileStorage(join(__dirname, '__cassettes__')));
     vcr.requestMasker = (req) => {
       req.headers['user-agent'] = '****';

--- a/src/vcr.ts
+++ b/src/vcr.ts
@@ -16,9 +16,9 @@ export class VCR {
 
   constructor (private readonly storage: ICassetteStorage) {}
 
-  public async useCassette(name: string, action: () => Promise<void>) {
+  public async useCassette(name: string, action: () => Promise<void>, hostsBlacklist: string[] = []): Promise<void> {
     const mode = ENV_TO_RECORD_MODE[process.env.VCR_MODE ?? RecordMode.once] ?? RecordMode.once
-    var cassette = new Cassette(this.storage, this.matcher, name, mode, this.requestMasker);
+    var cassette = new Cassette(this.storage, this.matcher, name, mode, this.requestMasker, hostsBlacklist);
     await cassette.mount();
     try {
       await action();


### PR DESCRIPTION
this adds the possibility to bypass request interception for specific hosts.

I needed it in combination with Supertest which requests internally at `127.0.0.1`.
